### PR TITLE
Update required Python version in REAMDE to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ## Requirements
 
 * [FFmpeg](https://ffmpeg.org/)
-* \>= Python3.10
+* \>= Python3.11
 * GPU  processing requires:
   * Nvidia GPU (CUDA: cuBLAS and cuDNN for CUDA 12)
   * Apple Metal Performance Shaders (MPS) (Mac M1-M4)


### PR DESCRIPTION
Update required Python version in README to 3.11 so it matches the config: 
https://github.com/tsmdt/whisply/blob/e32d335180e2c9528f6e5f6500285f09c38add11/setup.cfg#L13

(In fact it fails with 3.10)