### PR TITLE
Exclude work- and resultfiles from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/app_*
 /dev
 /downloads*
 /transcriptions


### PR DESCRIPTION
Exclude work files in `/app_uploads` and the transcriptions in `app_transcriptions` from git. 